### PR TITLE
🐛 Terminate jupyterlab process in Linux and macOS

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -238,8 +238,9 @@ class JupyterServer {
                         res();
                     });
                 } else {
-                    this._nbServer.kill();
-                    res();
+                    execFile('pkill', ['-TERM', '-P', String(this._nbServer.pid)], () => {
+                        res();
+                    });
                 }
             } else {
                 res();


### PR DESCRIPTION
# Description
* Linux 와 macOS 에서 desktop application 이 종료될 때 `python -m jupyterlab ...` 프로세스가 종료되지 않는 문제를 해결합니다.